### PR TITLE
Configure TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+sudo: required
+services:
+ - docker
+addons:
+  apt:
+    packages:
+    - nodejs
+    - npm
+install:
+  - npm install -g dockerfile_lint
+before_script:
+  - dockerfile_lint -f Dockerfile
+script:
+  - docker build --rm=true --tag=sonatype/nexus3 .

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,8 +76,10 @@ RUN useradd -l -u ${USER_UID} -r -g 0 -m -d ${NEXUS_DATA} -s /sbin/no-login \
 
 VOLUME ${NEXUS_DATA}
 
-USER ${USER_NAME}
-WORKDIR ${NEXUS_HOME}
+# Supply non variable to USER command ${USER_NAME}
+USER nexus
+# Supply non variable to WORKDIR command ${NEXUS_HOME}
+WORKDIR /opt/sonatype/nexus
 
 ENV JAVA_MAX_MEM=1200m \
     JAVA_MIN_MEM=1200m

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM       centos:centos7
+FROM       registry.access.redhat.com/rhel7/rhel
 MAINTAINER Sonatype <cloud-ops@sonatype.com>
 
 # Atomic Labels
@@ -38,18 +38,14 @@ LABEL io.k8s.description="The Nexus Repository Manager server \
 LABEL com.sonatype.license="Apache License, Version 2.0"
 
 # Install Runtime Environment
-ENV JAVA_VERSION_MAJOR=8 \
-    JAVA_VERSION_MINOR=102 \
-    JAVA_VERSION_BUILD=14
-
-RUN yum install -y --setopt=tsflags=nodocs curl tar && \
+RUN set -x && \
     yum clean all && \
-    curl --remote-name --fail --silent --location --retry 3 \
-        --header "Cookie: oraclelicense=accept-securebackup-cookie; " \
-        http://download.oracle.com/otn-pub/java/jdk/${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-b${JAVA_VERSION_BUILD}/jdk-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.rpm && \
-    yum localinstall -y jdk-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.rpm && \
-    yum clean all && \
-    rm jdk-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.rpm
+    yum-config-manager --disable \* && \
+    yum-config-manager --enable rhel-7-server-rpms && \
+    yum-config-manager --enable rhel-7-server-thirdparty-oracle-java-rpms && \
+    yum -y update-minimal --security --sec-severity=Important --sec-severity=Critical --setopt=tsflags=nodocs && \
+    yum -y install --setopt=tsflags=nodocs tar java-1.8.0-oracle-devel && \
+    yum clean all
 
 # Install Nexus
 ENV NEXUS_DATA=/nexus-data \


### PR DESCRIPTION
- Introduce Travis CI to project
- Use CentOS for main dockerfile
- Provide rhel7 docker file for rhel7 install

This allows for native docker builds in OpenShift which does not have RHEL subscriptions. Also provides the ability to push to DockerHub as desired. This begs the question if we should merge with the sonatype/docker-nexus3 repository (@DarthHater).

Fixes #1 
Fixes #11 
