### PR TITLE
Configure TravisCI (Nexus2)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+sudo: required
+services:
+ - docker
+addons:
+  apt:
+    packages:
+    - nodejs
+    - npm
+install:
+  - npm install -g dockerfile_lint
+before_script:
+  - dockerfile_lint -f oss/Dockerfile
+  - dockerfile_lint -f pro/Dockerfile
+script:
+  - docker build --rm --tag sonatype/nexus-oss oss/
+  - docker build --rm --tag sonatype/nexus-pro pro/

--- a/oss/Dockerfile
+++ b/oss/Dockerfile
@@ -75,7 +75,7 @@ RUN useradd -l -u ${USER_UID} -r -g 0 -m -d ${NEXUS_WORK} -s /sbin/no-login \
 
 COPY scripts/fix-permissions.sh /usr/local/bin/
 
-RUN chmod 755 /usr/local/bin/fix-permissions.sh && \
+RUN chmod 755 /usr/local/bin/fix-permissions.sh && sync && \
     /usr/local/bin/fix-permissions.sh ${NEXUS_WORK} && \
     /usr/local/bin/fix-permissions.sh ${NEXUS_REPOS} && \
     /usr/local/bin/fix-permissions.sh ${APPLICATION_CONF} && \

--- a/oss/Dockerfile.rhel7
+++ b/oss/Dockerfile.rhel7
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM       centos:centos7
+FROM       registry.access.redhat.com/rhel7/rhel
 MAINTAINER Sonatype <cloud-ops@sonatype.com>
 
 # Atomic Labels
@@ -38,18 +38,14 @@ LABEL io.k8s.description="The Nexus Repository Manager server \
 LABEL com.sonatype.license="Apache License, Version 2.0"
 
 # Install Runtime Environment
-ENV JAVA_VERSION_MAJOR=8 \
-    JAVA_VERSION_MINOR=102 \
-    JAVA_VERSION_BUILD=14
-
-RUN yum install -y --setopt=tsflags=nodocs curl tar && \
+RUN set -x && \
     yum clean all && \
-    curl --remote-name --fail --silent --location --retry 3 \
-        --header "Cookie: oraclelicense=accept-securebackup-cookie; " \
-        http://download.oracle.com/otn-pub/java/jdk/${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-b${JAVA_VERSION_BUILD}/jdk-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.rpm && \
-    yum localinstall -y jdk-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.rpm && \
-    yum clean all && \
-    rm jdk-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.rpm
+    yum-config-manager --disable \* && \
+    yum-config-manager --enable rhel-7-server-rpms && \
+    yum-config-manager --enable rhel-7-server-thirdparty-oracle-java-rpms && \
+    yum -y update-minimal --security --sec-severity=Important --sec-severity=Critical --setopt=tsflags=nodocs && \
+    yum -y install --setopt=tsflags=nodocs tar java-1.8.0-oracle-devel && \
+    yum clean all
 
 # Install Nexus
 ENV NEXUS_HOME=/opt/sonatype/nexus \

--- a/oss/Dockerfile.rhel7
+++ b/oss/Dockerfile.rhel7
@@ -71,7 +71,7 @@ RUN useradd -l -u ${USER_UID} -r -g 0 -m -d ${NEXUS_WORK} -s /sbin/no-login \
 
 COPY scripts/fix-permissions.sh /usr/local/bin/
 
-RUN chmod 755 /usr/local/bin/fix-permissions.sh && \
+RUN chmod 755 /usr/local/bin/fix-permissions.sh && sync && \
     /usr/local/bin/fix-permissions.sh ${NEXUS_WORK} && \
     /usr/local/bin/fix-permissions.sh ${NEXUS_REPOS} && \
     /usr/local/bin/fix-permissions.sh ${APPLICATION_CONF} && \

--- a/pro/Dockerfile
+++ b/pro/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM       registry.access.redhat.com/rhel7/rhel
+FROM       centos:centos7
 MAINTAINER Sonatype <cloud-ops@sonatype.com>
 
 # Atomic Labels
@@ -34,20 +34,24 @@ LABEL io.k8s.description="The Nexus Repository Manager server \
       io.openshift.expose-services="8081:8081" \
       io.openshift.tags="Sonatype,Nexus"
 
-
 # Sonatype Labels
 LABEL com.sonatype.license="Apache License, Version 2.0"
 
 # Install Runtime Environment
-RUN set -x && \
-    yum clean all && \
-    yum-config-manager --disable \* && \
-    yum-config-manager --enable rhel-7-server-rpms && \
-    yum-config-manager --enable rhel-7-server-thirdparty-oracle-java-rpms && \
-    yum -y update-minimal --security --sec-severity=Important --sec-severity=Critical --setopt=tsflags=nodocs && \
-    yum -y install --setopt=tsflags=nodocs tar java-1.8.0-oracle-devel && \
-    yum clean all
+ENV JAVA_VERSION_MAJOR=8 \
+    JAVA_VERSION_MINOR=102 \
+    JAVA_VERSION_BUILD=14
 
+RUN yum install -y --setopt=tsflags=nodocs curl tar && \
+    yum clean all && \
+    curl --remote-name --fail --silent --location --retry 3 \
+        --header "Cookie: oraclelicense=accept-securebackup-cookie; " \
+        http://download.oracle.com/otn-pub/java/jdk/${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-b${JAVA_VERSION_BUILD}/jdk-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.rpm && \
+    yum localinstall -y jdk-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.rpm && \
+    yum clean all && \
+    rm jdk-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.rpm
+
+# Install Nexus
 ENV NEXUS_HOME=/opt/sonatype/nexus \
     NEXUS_WORK=/sonatype-work \
     NEXUS_REPOS=/repositories \
@@ -82,8 +86,10 @@ RUN chmod 755 /usr/local/bin/fix-permissions.sh && \
 VOLUME ${NEXUS_WORK}
 VOLUME ${NEXUS_REPOS}
 
-USER ${USER_NAME}
-WORKDIR ${NEXUS_HOME}
+# Supply non variable to USER command ${USER_NAME}
+USER nexus
+# Supply non variable to WORKDIR command ${NEXUS_HOME}
+WORKDIR /opt/sonatype/nexus
 
 ENV CONTEXT_PATH=/ \
     MAX_HEAP=768m \

--- a/pro/Dockerfile
+++ b/pro/Dockerfile
@@ -75,7 +75,7 @@ RUN useradd -l -u ${USER_UID} -r -g 0 -m -d ${NEXUS_WORK} -s /sbin/no-login \
 
 COPY scripts/fix-permissions.sh /usr/local/bin/
 
-RUN chmod 755 /usr/local/bin/fix-permissions.sh && \
+RUN chmod 755 /usr/local/bin/fix-permissions.sh && sync && \
     /usr/local/bin/fix-permissions.sh ${NEXUS_WORK} && \
     /usr/local/bin/fix-permissions.sh ${NEXUS_REPOS} && \
     /usr/local/bin/fix-permissions.sh ${APPLICATION_CONF} && \

--- a/pro/Dockerfile.rhel7
+++ b/pro/Dockerfile.rhel7
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM       centos:centos7
+FROM       registry.access.redhat.com/rhel7/rhel
 MAINTAINER Sonatype <cloud-ops@sonatype.com>
 
 # Atomic Labels
-LABEL name="Nexus 2 OSS" \
+LABEL name="Nexus 2 Pro" \
       vendor="Sonatype" \
       version="2.14.0-01" \
       url="https://sonatype.com" \
@@ -30,7 +30,7 @@ LABEL name="Nexus 2 OSS" \
 # OpenShift Labels
 LABEL io.k8s.description="The Nexus Repository Manager server \
           with universal support for popular component formats." \
-      io.k8s.display-name="Nexus 2 OSS" \
+      io.k8s.display-name="Nexus 2 Pro" \
       io.openshift.expose-services="8081:8081" \
       io.openshift.tags="Sonatype,Nexus"
 
@@ -38,18 +38,14 @@ LABEL io.k8s.description="The Nexus Repository Manager server \
 LABEL com.sonatype.license="Apache License, Version 2.0"
 
 # Install Runtime Environment
-ENV JAVA_VERSION_MAJOR=8 \
-    JAVA_VERSION_MINOR=102 \
-    JAVA_VERSION_BUILD=14
-
-RUN yum install -y --setopt=tsflags=nodocs curl tar && \
+RUN set -x && \
     yum clean all && \
-    curl --remote-name --fail --silent --location --retry 3 \
-        --header "Cookie: oraclelicense=accept-securebackup-cookie; " \
-        http://download.oracle.com/otn-pub/java/jdk/${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-b${JAVA_VERSION_BUILD}/jdk-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.rpm && \
-    yum localinstall -y jdk-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.rpm && \
-    yum clean all && \
-    rm jdk-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.rpm
+    yum-config-manager --disable \* && \
+    yum-config-manager --enable rhel-7-server-rpms && \
+    yum-config-manager --enable rhel-7-server-thirdparty-oracle-java-rpms && \
+    yum -y update-minimal --security --sec-severity=Important --sec-severity=Critical --setopt=tsflags=nodocs && \
+    yum -y install --setopt=tsflags=nodocs tar java-1.8.0-oracle-devel && \
+    yum clean all
 
 # Install Nexus
 ENV NEXUS_HOME=/opt/sonatype/nexus \
@@ -62,11 +58,11 @@ ENV NEXUS_HOME=/opt/sonatype/nexus \
 
 RUN mkdir -p ${NEXUS_HOME} && \
     curl --fail --silent --location --retry 3 \
-      https://download.sonatype.com/nexus/oss/nexus-${NEXUS_VERSION}-bundle.tar.gz \
+      https://download.sonatype.com/nexus/professional-bundle/nexus-professional-${NEXUS_VERSION}-bundle.tar.gz \
       | gunzip \
-      | tar x -C /tmp nexus-${NEXUS_VERSION} && \
-    mv /tmp/nexus-${NEXUS_VERSION}/* ${NEXUS_HOME}/ && \
-    rm -rf /tmp/nexus-${NEXUS_VERSION} && \
+      | tar x -C /tmp nexus-professional-${NEXUS_VERSION} && \
+    mv /tmp/nexus-professional-${NEXUS_VERSION}/* ${NEXUS_HOME}/ && \
+    rm -rf /tmp/nexus-professional-${NEXUS_VERSION} && \
     mkdir -p ${NEXUS_REPOS} && \
     mkdir -p ${APPLICATION_CONF}
 

--- a/pro/Dockerfile.rhel7
+++ b/pro/Dockerfile.rhel7
@@ -71,7 +71,7 @@ RUN useradd -l -u ${USER_UID} -r -g 0 -m -d ${NEXUS_WORK} -s /sbin/no-login \
 
 COPY scripts/fix-permissions.sh /usr/local/bin/
 
-RUN chmod 755 /usr/local/bin/fix-permissions.sh && \
+RUN chmod 755 /usr/local/bin/fix-permissions.sh && sync && \
     /usr/local/bin/fix-permissions.sh ${NEXUS_WORK} && \
     /usr/local/bin/fix-permissions.sh ${NEXUS_REPOS} && \
     /usr/local/bin/fix-permissions.sh ${APPLICATION_CONF} && \


### PR DESCRIPTION
- Introduce Travis CI to project
- Use CentOS for main dockerfile
- Provide rhel7 docker file for rhel7 install

This allows for native docker builds in OpenShift which does not have RHEL subscriptions. Also provides the ability to push to DockerHub as desired. This begs the question if we should merge with the sonatype/docker-nexus3 repository (@DarthHater).

Fixes #1 
Fixes #11
